### PR TITLE
chore: reducing docker image by ~600mb

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1
-FROM python:3.8-slim-buster
+FROM tensorflow/tensorflow
 WORKDIR /app
 COPY require.txt .
 RUN pip install -r require.txt

--- a/require.txt
+++ b/require.txt
@@ -1,5 +1,3 @@
-numpy
 Pillow
 flask
-tensorflow
 waitress


### PR DESCRIPTION
The built docker image is about 1.97GB(!)
Ive tried to reduce it by using official tensorflow as base,
and removing some dependencies (tensorflow and numpy is already included in the base image)

@joshclement0 I've got no experience with tensorflow or python, so you'll need to verify that this still works as intended ;)